### PR TITLE
ACL check problem

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -613,7 +613,7 @@ class syntax_plugin_filelist extends DokuWiki_Syntax_Plugin {
                     if (!$params['direct']) {
                         // exclude prohibited media files via ACLs
                         $mid = str_replace('/', ':', substr($filepath, strlen($this->mediadir)));
-                        $perm = auth_quickaclcheck($mid);
+                        $perm = auth_quickaclcheck(ltrim($mid,":"));
                         if ($perm < AUTH_READ) continue;
                     } else {
                         if (!is_readable($filepath)) continue;


### PR DESCRIPTION
I like your plugin and need to use it in non-public wiki, so I tryied to solve the ACL check problem mentioned here: http://www.foosel.org/snippets/dokuwiki/filelist (comment from mk, 2011/10/25 21:03). I don't know DokuWiki well enough, but it solved my problem with not displaying file-listing to logged-in user with rights defined for given parent namespace.

Pavel
