### PR TITLE
add image preview in table view

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -304,6 +304,12 @@ class syntax_plugin_filelist extends DokuWiki_Syntax_Plugin {
                 $renderer->tableheader_close();
             }
 
+            if ($params['tableshowimagepreview']) {
+                $renderer->tableheader_open();
+                $renderer->doc .= $this->getLang('preview');
+                $renderer->tableheader_close();
+            }
+
         }
 
         foreach ($result['files'] as $file) {
@@ -323,6 +329,38 @@ class syntax_plugin_filelist extends DokuWiki_Syntax_Plugin {
                 $renderer->doc .= strftime($conf['dformat'], $file['mtime']);
                 $renderer->tablecell_close();
             }
+            
+            if ($params['tableshowimagepreview']) {
+                $renderer->tablecell_open();
+			    $x = getimagesize($file['path']);
+				$isImage=FALSE;
+
+			    switch ($x['mime']) {
+				  case "image/gif":
+					 $isImage=TRUE;
+					 break;
+				  case "image/jpeg":
+					 $isImage=TRUE;
+					 break;
+				  case "image/png":
+					 $isImage=TRUE;
+					 break;
+				  default:
+					 break;
+			    }
+				
+				if ($isImage) {
+					if (!$params['direct']) {
+						$imgLink = ml(':'.$this->_convert_mediapath($file['path']));
+					} else {
+						$imgLink = $result['webdir'].substr($file['path'], strlen($result['basedir']));
+					}
+					
+					$renderer->doc .= '<img class="preview" style=" max-height: 25px; max-width: 25px;" src="'.$imgLink.'">';
+				}
+					
+                $renderer->tablecell_close();
+            }            
 
             $renderer->tablerow_close();
         }


### PR DESCRIPTION
Add an image preview in table view. This adds a small preview image of the listed image. The added class "preview" allows for JavaScripts based zoom functionality in user based templates.

Sample zoom functionality:
```javascript
jQuery(function() {
	/* CONFIG */
		
		xOffset = 10;
		yOffset = 30;
		
		// these 2 variable determine popup's distance from the cursor
		// you might want to adjust to get the right result
		
	/* END CONFIG */
	jQuery("img.preview").hover(function(e){
		this.t = this.title;
		this.title = "";	
		var c = (this.t != "") ? "<br/>" + this.t : "";
		jQuery("body").append("<p id='preview'><img src='"+ this.src +"' alt='Image preview' />"+ c +"</p>");								 
		jQuery("#preview")
			.css("top",(e.pageY - xOffset) + "px")
			.css("left",(e.pageX + yOffset) + "px")
			.css("max-width","300px")
			.css("max-height","300px")
			.css("position", "absolute")
			.fadeIn("fast");						
    },
	function(){
		this.title = this.t;	
		jQuery("#preview").remove();
    });	
	jQuery("img.preview").mousemove(function(e){
		jQuery("#preview")
			.css("top",(e.pageY - xOffset) + "px")
			.css("left",(e.pageX + yOffset) + "px")
			.css("position", "absolute");

	});			
});
```